### PR TITLE
docs: Add auto-modeling and landing page

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,6 +32,12 @@ jobs:
 
       - uses: actions/checkout@v2
 
+      - uses: webfactory/ssh-agent@v0.4.1
+        with:
+          ssh-private-key: ${{ secrets.AUTO_MODELING_DEPLOY_KEY }}
+
+      - run: git config --global credential.helper store  &&  git ls-remote -h https://github.com/InferenceQL/inferenceql.auto-modeling > /dev/null
+
       - uses: actions/cache@v2
         with:
           path: ~/.m2

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,12 +32,6 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: webfactory/ssh-agent@v0.4.1
-        with:
-          ssh-private-key: ${{ secrets.AUTO_MODELING_DEPLOY_KEY }}
-
-      - run: git config --global credential.helper store  &&  git ls-remote -h https://github.com/InferenceQL/inferenceql.auto-modeling > /dev/null
-
       - uses: actions/cache@v2
         with:
           path: ~/.m2
@@ -58,6 +52,8 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
+
+      - run: git config --global credential.helper store && echo "https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com" > ~/.git-credentials
 
       - run: bb js:deps
 

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -3,10 +3,14 @@ antora:
     - ./lib/my-extension.js
 site:
   title: InferenceQL
-  start_page: query::iql-strict.adoc
+  start_page: start-page::start-page.adoc
 content:
   sources:
+    - url: ./
+      start_path: docs
     - url: https://github.com/InferenceQL/inferenceql.query
+      start_path: docs
+    - url: git@github.com:InferenceQL/inferenceql.auto-modeling.git
       start_path: docs
 ui:
   bundle:

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,0 +1,6 @@
+name: start-page
+title: Overview
+version: ~
+start_page: start-page.adoc
+nav:
+- modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,0 +1,5 @@
+* xref:auto-modeling::quick-start.adoc[Quickstart]
+* xref:auto-modeling::auto-modeling.adoc[Automated data modeling]
+* Languages
+** xref:query::iql-permissive.adoc[IQL-permissive]
+** xref:query::iql-strict.adoc[IQL-strict]

--- a/docs/modules/ROOT/pages/start-page.adoc
+++ b/docs/modules/ROOT/pages/start-page.adoc
@@ -1,0 +1,40 @@
+= Platform Documentation
+Ulli Schaechtle <u.schaechtle@gmail.com>
+
+This site hosts technical documentation for the InferenceQL platform.
+
+== Disclaimer
+
+**InferenceQL is pre-alpha / unreleased software.** There are known and unknown isues and bugs. Crashes are expected.  This software should not be expected to treat your data securely.
+
+== Content
+
+Welcome to our first attempt to document the InferenceQL platform. The
+documenation covers:
+
+* xref:auto-modeling::quick-start.adoc[Quickstart]
+
+* xref:auto-modeling::auto-modeling.adoc[Automated data modeling]
+
+* Inference Query language
+** xref:query::iql-permissive.adoc[Query language (IQL-permissive)]
+** xref:query::iql-permissive.adoc[Research Query Language -- aimed at PL researchers (IQL-permissive)]
+
+We recommend all users begin with the xref:auto-modeling::quick-start.adoc[Quickstart] tutorial.
+
+== Open-source code
+
+Please find our open source code https://github.com/OpenIQL[here].
+
+== Citation
+
+Please cite this work via: TBD.
+
+== License
+
+All of InferenceQL is open source and licensed under Apache 2.0. At times, the
+InferenceQL teams maintains private repos hosting components of InferenceQL to
+prepare an OSS release. If you happen to have privileged private access -
+please don't share it pre-release.
+
+


### PR DESCRIPTION
### What does this do?

Adds a landing page and links up documentation for automated data modeling. It also adds a GitHub secret for deployment -- so that the GitHub workflow can read auto-modeling. 
