### PR TITLE
fix: Rename auto-modeling to structure learning

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -10,7 +10,7 @@ content:
       start_path: docs
     - url: https://github.com/InferenceQL/inferenceql.query
       start_path: docs
-    - url: git@github.com:InferenceQL/inferenceql.auto-modeling.git
+    - url: git@github.com:InferenceQL/inferenceql.structure-learning.git
       start_path: docs
 ui:
   bundle:

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,5 +1,5 @@
-* xref:auto-modeling::quick-start.adoc[Quickstart]
-* xref:auto-modeling::auto-modeling.adoc[Automated data modeling]
+* xref:structure-learning::quick-start.adoc[Quickstart]
+* xref:structure-learning::structure-learning.adoc[Structure learning]
 * Languages
 ** xref:query::iql-permissive.adoc[IQL-permissive]
 ** xref:query::iql-strict.adoc[IQL-strict]

--- a/docs/modules/ROOT/pages/start-page.adoc
+++ b/docs/modules/ROOT/pages/start-page.adoc
@@ -12,15 +12,15 @@ This site hosts technical documentation for the InferenceQL platform.
 Welcome to our first attempt to document the InferenceQL platform. The
 documentation covers:
 
-* xref:auto-modeling::quick-start.adoc[Quickstart]
+* xref:structure-learning::quick-start.adoc[Quickstart]
 
-* xref:auto-modeling::auto-modeling.adoc[Automated data modeling]
+* xref:structure-learning::structure-learning.adoc[Structure learning]
 
 * Inference Query language
 ** xref:query::iql-permissive.adoc[Query language (IQL-permissive)]
 ** xref:query::iql-permissive.adoc[Research Query Language -- aimed at PL researchers (IQL-permissive)]
 
-We recommend all users begin with the xref:auto-modeling::quick-start.adoc[Quickstart] tutorial.
+We recommend all users begin with the xref:structure-learning::quick-start.adoc[Quickstart] tutorial.
 
 == Open-source code
 

--- a/supplemental-ui/partials/header-content.hbs
+++ b/supplemental-ui/partials/header-content.hbs
@@ -17,7 +17,7 @@
           <div class="navbar-dropdown">
             <a class="navbar-item" href="https://github.com/InferenceQL/"><strong>InferenceIQL</strong></a>
             <a class="navbar-item" href="https://github.com/InferenceQL/inferenceql.query">iql.query</a>
-            <a class="navbar-item" href="https://github.com/InferenceQL/inferenceql.auto-modeling">iql.auto-modeling</a>
+            <a class="navbar-item" href="https://github.com/InferenceQL/inferenceql.structure-learning">iql.structure-learning</a>
             <a class="navbar-item" href="https://github.com/InferenceQL/inferenceql.inference">iql.inference</a>
             <a class="navbar-item" href="https://github.com/InferenceQL/inferenceql.gpm.spn">iql.gpm.spn</a>
             <a class="navbar-item" href="https://github.com/InferenceQL/inferenceql.gpm.glm">iql.gpm.glm</a>


### PR DESCRIPTION
The recent renaming of auto-modeling resulted in broken links.