### PR TITLE
Make GH Action deploy work again

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,24 +13,28 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-java@v3
-        with:
-          distribution: adopt
-          java-version: 11
+      - uses: actions/checkout@v4
 
-      - uses: DeLaGuardo/setup-clojure@master
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+
+      - uses: DeLaGuardo/setup-clojure@12.5
         with:
           bb: 0.8.157
-          tools-deps: 1.10.3.1040
+          cli: 1.10.3.1040
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v3
         with:
-          version: 7.4.1
-          run_install: false
+          version: 8
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - uses: actions/checkout@v2
 
       - uses: actions/cache@v2
         with:

--- a/fly.toml
+++ b/fly.toml
@@ -43,3 +43,4 @@ kill_timeout = '5s'
 
 [[vm]]
   size = 'shared-cpu-1x'
+  memory = '512mb'


### PR DESCRIPTION
Upgrading packages to get the commit linter action working apparently broke the old deploy action.